### PR TITLE
Bug fix for assets host version

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -74,8 +74,8 @@ module Sprockets
         app.assets.version,
         config.assets.version,
         config.action_controller.relative_url_root,
-        config.action_controller.asset_host,
-        Sprockets::Rails::VERSION,
+        (config.action_controller.asset_host unless config.action_controller.asset_host.respond_to?(:call)),
+        Sprockets::Rails::VERSION
       ].compact.join('-')
 
       # Copy config.assets.paths to Sprockets

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -112,7 +112,7 @@ class TestRailtie < TestBoot
     assert_equal "test-v2-#{Sprockets::Rails::VERSION}", env.version
   end
 
-  def test_version_fragments
+  def test_version_fragments_with_string_asset_host
     app.configure do
       config.assets.version = 'v2'
       config.action_controller.asset_host = 'http://some-cdn.com'
@@ -122,6 +122,20 @@ class TestRailtie < TestBoot
 
     assert env = app.assets
     assert_equal "test-v2-some-path-http://some-cdn.com-#{Sprockets::Rails::VERSION}", env.version
+  end
+
+  def test_version_fragments_with_proc_asset_host
+    app.configure do
+      config.assets.version = 'v2'
+      config.action_controller.asset_host = ->(path, request) {
+        'http://some-cdn.com'
+      }
+      config.action_controller.relative_url_root = 'some-path'
+    end
+    app.initialize!
+
+    assert env = app.assets
+    assert_equal "test-v2-some-path-#{Sprockets::Rails::VERSION}", env.version
   end
 
   def test_configure


### PR DESCRIPTION
Assets version doesn't depend on asset host if it's a Proc

Workaround for sprockets-rails bug, introduced in version 2.1.3.
Details: rails#138

This pull request is meant for documentation purposes only.
